### PR TITLE
Move P2 Jump to Start of Executable

### DIFF
--- a/src/SH4.s
+++ b/src/SH4.s
@@ -10,19 +10,6 @@
 _SH4_init:
 
 !///////////////////////////////////////////////////////////////////////////////
-!// make sure to run in the P2 non-cacheable area (0xA0000000 - 0xBFFFFFFF)
-!///////////////////////////////////////////////////////////////////////////////
-.SH4_switch_to_P2:
-    mov.l SH4_CCR_init_ADDR, R0 
-    mov.l RAM_ADDRESS_MASK, R1
-    and R1, R0                            ! remove the P-Area bits
-    mov.l RAM_AREA_P2_MASK, R1
-    or R1, R0                             ! set the P-Area to P2 non-cacheable area
-	jmp	@R0
-	nop
-    nop                                   ! for alignment
-
-!///////////////////////////////////////////////////////////////////////////////
 !// Cache Controler (CCR) Initialization
 !///////////////////////////////////////////////////////////////////////////////
 .SH4_CCR_init:
@@ -113,13 +100,6 @@ _SH4_init:
 !///////////////////////////////////////////////////////////////////////////////
     .align 4
 
-SH4_CCR_init_ADDR:
-    .long .SH4_CCR_init
-
-RAM_ADDRESS_MASK:
-    .long        0x1FFFFFFF
-RAM_AREA_P2_MASK:
-    .long        0xA0000000
 
 CACHE_CCR_ADDR:                          ! Cache control register (CCR):
     .long        0xFF00001C              !    Initial: 0x00000000

--- a/src/jinGasa.s
+++ b/src/jinGasa.s
@@ -9,6 +9,19 @@
     .text
 
 .start:
+!///////////////////////////////////////////////////////////////////////////////
+!// make sure to run in the P2 non-cacheable area (0xA0000000 - 0xBFFFFFFF)
+!///////////////////////////////////////////////////////////////////////////////
+ .SH4_switch_to_P2:
+    mov.l JINGASA_INIT_ADDR, R0 
+    mov.l RAM_ADDRESS_MASK, R1
+    and R1, R0                            ! remove the P-Area bits
+    mov.l RAM_AREA_P2_MASK, R1
+    or R1, R0                             ! set the P-Area to P2 non-cacheable area
+	jmp	@R0
+	nop
+    nop                                   ! for alignment
+
 _jinGasa_init:
 
 !///////////////////////////////////////////////////////////////////////////////
@@ -60,6 +73,12 @@ dcloadserial_copy_loop:
 JINGASA_START_ADDR:
     .long        .start                   ! Where this BIOS is loaded in RAM. Will be used for relative offsets
 
+RAM_ADDRESS_MASK:
+    .long        0x1FFFFFFF
+RAM_AREA_P2_MASK:
+    .long        0xA0000000
+JINGASA_INIT_ADDR:
+    .long        _jinGasa_init
 SH4_INIT_ADDR:
     .long        _SH4_init
 HOLLY_INIT_ADDR:


### PR DESCRIPTION
Previously upon return from the SH4 init we would go back to the callers address instead of staying in P2. By jumping to the P2 area initially we skip any issues with returning to the wrong area when returning from the SH4 setup.